### PR TITLE
Use imagePullPolicy: Always when using “latest” tags

### DIFF
--- a/remotemonitoring/scripts/all-in-one.yaml
+++ b/remotemonitoring/scripts/all-in-one.yaml
@@ -55,6 +55,7 @@ spec:
       containers:
       - name: device-simulation-pod
         image: azureiotpcs/device-simulation-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9003
       env:
@@ -106,6 +107,7 @@ spec:
       containers:
       - name: iothub-manager-pod
         image: azureiotpcs/iothub-manager-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9002
         env:
@@ -154,6 +156,7 @@ spec:
       containers:
       - name: device-telemetry-pod
         image: azureiotpcs/device-telemetry-java:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9004
         env:
@@ -205,6 +208,7 @@ spec:
       containers:
       - name: storage-adapter-pod
         image: azureiotpcs/pcs-storage-adapter-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9022
         env:
@@ -258,6 +262,7 @@ spec:
       containers:
       - name: stream-analytics-pod
         image: azureiotpcs/iot-stream-analytics-java:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9023
         env:
@@ -326,6 +331,7 @@ spec:
       containers:
       - name: ui-config-pod
         image: azureiotpcs/pcs-ui-config-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9005
         env:
@@ -374,6 +380,7 @@ spec:
       containers:
       - name: remote-monitoring-webui-pod
         image: azureiotpcs/pcs-remote-monitoring-webui:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
 ---

--- a/remotemonitoring/scripts/individual/device-simulation.yaml
+++ b/remotemonitoring/scripts/individual/device-simulation.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: device-simulation-pod
         image: azureiotpcs/device-simulation-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9003
         env:

--- a/remotemonitoring/scripts/individual/device-telemetry.yaml
+++ b/remotemonitoring/scripts/individual/device-telemetry.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: device-telemetry-pod
         image: azureiotpcs/device-telemetry-java:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9004
         env:

--- a/remotemonitoring/scripts/individual/iothub-manager.yaml
+++ b/remotemonitoring/scripts/individual/iothub-manager.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: iothub-manager-pod
         image: azureiotpcs/iothub-manager-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9002
         env:

--- a/remotemonitoring/scripts/individual/remote-monitoring-webui.yaml
+++ b/remotemonitoring/scripts/individual/remote-monitoring-webui.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: remote-monitoring-webui-pod
         image: azureiotpcs/pcs-remote-monitoring-webui:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
 ---

--- a/remotemonitoring/scripts/individual/storage-adapter.yaml
+++ b/remotemonitoring/scripts/individual/storage-adapter.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: storage-adapter-pod
         image: azureiotpcs/pcs-storage-adapter-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9022
         env:

--- a/remotemonitoring/scripts/individual/stream-analytics.yaml
+++ b/remotemonitoring/scripts/individual/stream-analytics.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: stream-analytics-pod
         image: azureiotpcs/iot-stream-analytics-java:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9023
         env:

--- a/remotemonitoring/scripts/individual/ui-config.yaml
+++ b/remotemonitoring/scripts/individual/ui-config.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: ui-config-pod
         image: azureiotpcs/pcs-ui-config-dotnet:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 9005
         env:


### PR DESCRIPTION
# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

# Description of the change
When using the "latest" tag it's better to force k8s to pull the images, otherwise the orchestrator will cache images without any way to know which "latest" is in the cache.

# Motivation for the change
Make deployment easier and more predictable. However, before launch we should change the policy back to default and not use the "latest" tag.
