### PR TITLE
Create fingerprint of certificate that matches how reverse proxy creates it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iotsuite-cli",
-  "version": "1.0.0-preview",
+  "version": "1.0.1-preview",
   "description": "Command Line Interface for deploying pre-configured IoT solutions through Azure",
   "main": "./publish/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,17 +416,18 @@ function createCertificate(): any {
     const pki: any = forge.pki;
     // generate a keypair and create an X.509v3 certificate
     const keys = pki.rsa.generateKeyPair(2048);
-    const cert = pki.createCertificate();
-    cert.publicKey = keys.publicKey;
-    cert.serialNumber = '01';
-    cert.validity.notBefore = new Date(Date.now());
-    cert.validity.notAfter = new Date(Date.now());
-    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+    const certificate = pki.createCertificate();
+    certificate.publicKey = keys.publicKey;
+    certificate.serialNumber = '01';
+    certificate.validity.notBefore = new Date(Date.now());
+    certificate.validity.notAfter = new Date(Date.now());
+    certificate.validity.notAfter.setFullYear(certificate.validity.notBefore.getFullYear() + 1);
     // self-sign certificate
-    cert.sign(keys.privateKey);
-    const fingerPrint = pki.getPublicKeyFingerprint(keys.publicKey, {encoding: 'hex', delimiter: ':'});
+    certificate.sign(keys.privateKey);
+    const cert = forge.pki.certificateToPem(certificate);
+    const fingerPrint = forge.md.sha1.create().update(forge.asn1.toDer(pki.certificateToAsn1(certificate)).getBytes()).digest().toHex();
     return {
-        cert: forge.pki.certificateToPem(cert),
+        cert,
         fingerPrint,
         key: forge.pki.privateKeyToPem(keys.privateKey)
     };


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
The fingerprint was created for public key which was wrong. We need to get the fingerprint of the certificate that will match what reverse proxy does when it gets the request.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
So we can validate the thumbprint of the certificate that was created at deployment time.
