### PR TITLE
Add headers to disable browsers’ mime sniffing and protect from clickjacking

### DIFF
--- a/remotemonitoring/scripts/individual/deployment-configmap.yaml
+++ b/remotemonitoring/scripts/individual/deployment-configmap.yaml
@@ -272,8 +272,8 @@ data:
 
                       # Don't allow the browser to render the page inside a frame/iframe
                       # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking
-                      # If you need to [i]frames, use SAMEORIGIN or set an uri with ALLOW-FROM uri
-                      # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+                      # If you need [i]frames, use SAMEORIGIN or set an uri with ALLOW-FROM uri
+                      # See https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
                       add_header X-Frame-Options SAMEORIGIN always;
 
                       {{- range $location := $server.Locations }}


### PR DESCRIPTION
# Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
When serving any content, include a "X-Content-Type-Options: nosniff" header along with the Content-Type: header, to disable content-type sniffing on some browsers. Also add "X-Frame-Options SAMEORIGIN" to protect the user against clickjacking.