### PR TITLE
Add elapsed time to bottom bar, will show when operation status is available

### DIFF
--- a/src/deployui.ts
+++ b/src/deployui.ts
@@ -70,8 +70,14 @@ class DeployUI {
                             if (this.totalResourceCount > options.totalResources) {
                                 options.totalResources = this.totalResourceCount;
                             }
+                            const elapsedTime: Date = new Date(Date.now() - this.startTime);
                             operationsStatus += loader + this.deployedResources +
-                            `${chalk.cyan(this.completedResourceCount.toString(), 'of', options.totalResources.toString())}`;
+                            `${chalk.cyan(
+                                this.completedResourceCount.toString(), 'of',
+                                options.totalResources.toString())}` + '\t(Elapsed Time: ' +
+                            `${chalk.cyan(
+                                elapsedTime.getMinutes().toString(), 'minutes &',
+                                elapsedTime.getSeconds().toString(), 'seconds')})`;
                             this.ui.updateBottomBar(operationsStatus);
                         } else {
                             this.ui.updateBottomBar(loader + this.deploying);


### PR DESCRIPTION
# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

<img width="552" alt="elapsedtime" src="https://user-images.githubusercontent.com/558813/31335079-9271c14e-ad23-11e7-9753-a1cf23c15410.PNG">

Added convenience of seeing exact elapsed time instead of having to use a separate timer or wait until deployment completes before getting a time check.
