### PR TITLE
Temporarily change iothub-manager-java to iot-hub-manager-dotnet in Java deployment

### DIFF
--- a/remotemonitoring/scripts/all-in-one.yaml
+++ b/remotemonitoring/scripts/all-in-one.yaml
@@ -270,7 +270,7 @@ spec:
     spec:
       containers:
       - name: iothub-manager-pod
-        image: azureiotpcs/iothub-manager-{runtime}:testing
+        image: azureiotpcs/iothub-manager-dotnet:testing
         ports:
         - containerPort: 9002
         env:

--- a/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/remotemonitoring/single-vm/docker-compose.java.yml
@@ -39,7 +39,7 @@ services:
       - APPLICATION_SECRET
 
   iothubmanager:
-    image: azureiotpcs/iothub-manager-java:testing
+    image: azureiotpcs/iothub-manager-dotnet:testing
     environment:
       - PCS_IOTHUB_CONNSTRING
       # TODO: the dependency on config is temporary


### PR DESCRIPTION

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
The hubmanager java microservice has several bugs blocking critical functionality. Fixes are currently in progress, but may take a while. Until those are fixed we can move the java deployment to use the .Net service. 

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
