### PR TITLE
Link network security group to network controller interface

### DIFF
--- a/remotemonitoring/armtemplates/basic-static-map.json
+++ b/remotemonitoring/armtemplates/basic-static-map.json
@@ -283,6 +283,7 @@
     },
     "resources": [
         {
+            "comments": "AppService plan to host the Application Gateway Web App",
             "type": "Microsoft.Web/serverfarms",
             "sku": {
                 "name": "[variables('sku')]",
@@ -296,11 +297,14 @@
             }
         },
         {
+            "comments": "Application Gateway Web App",
             "type": "Microsoft.Web/sites",
             "name": "[parameters('azureWebsiteName')]",
             "apiVersion": "2015-08-01",
             "location": "[resourceGroup().location]",
             "properties": {
+                "enabled": true,
+                "clientAffinityEnabled": false,
                 "serverFarmId": "[variables('hostingPlanName')]",
                 "siteConfig": {
                     "appSettings": [
@@ -331,8 +335,7 @@
                 }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             ]
         },
         {
@@ -349,6 +352,7 @@
             }
         },
         {
+            "comments": "Azure CosmosDb",
             "apiVersion": "[variables('documentDBApiVersion')]",
             "type": "Microsoft.DocumentDb/databaseAccounts",
             "name": "[parameters('documentDBName')]",
@@ -367,6 +371,7 @@
             }
         },
         {
+            "comments": "Azure IoT Hub",
             "apiVersion": "[variables('iotHubApiVersion')]",
             "type": "Microsoft.Devices/Iothubs",
             "name": "[parameters('iotHubName')]",
@@ -384,6 +389,7 @@
             }
         },
         {
+            "comments": "Security rules used for the VM network interface",
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[variables('networkSecurityGroupName')]",
             "apiVersion": "[variables('networkApiVersion')]",
@@ -417,6 +423,7 @@
             }
         },
         {
+            "comments": "Public IP address used for the VM",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPName')]",
             "apiVersion": "2016-03-30",
@@ -433,6 +440,7 @@
             }
         },
         {
+            "comments": "Network interface used by the VM",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('nicName')]",
             "apiVersion": "[variables('networkApiVersion')]",
@@ -460,10 +468,14 @@
                             }
                         }
                     }
-                ]
+                ],
+                "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                }
             }
         },
         {
+            "comments": "VM running the microservices",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('vmName')]",
             "apiVersion": "[variables('computeApiVersion')]",
@@ -516,6 +528,7 @@
             }
         },
         {
+            "comments": "Docker extension used to run the microservices",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('vmName'), '/', 'DockerExtension')]",
             "apiVersion": "[variables('computeApiVersion')]",
@@ -534,6 +547,7 @@
             }
         },
         {
+            "comments": "One time script execution to prepare the VM environment",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('vmName'), '/', 'scriptextensions')]",
             "apiVersion": "[variables('computeApiVersion')]",

--- a/remotemonitoring/armtemplates/basic.json
+++ b/remotemonitoring/armtemplates/basic.json
@@ -292,6 +292,7 @@
     },
     "resources": [
         {
+            "comments": "AppService plan to host the Application Gateway Web App",
             "type": "Microsoft.Web/serverfarms",
             "sku": {
                 "name": "[variables('sku')]",
@@ -305,11 +306,14 @@
             }
         },
         {
+            "comments": "Application Gateway Web App",
             "type": "Microsoft.Web/sites",
             "name": "[parameters('azureWebsiteName')]",
             "apiVersion": "2015-08-01",
             "location": "[resourceGroup().location]",
             "properties": {
+                "enabled": true,
+                "clientAffinityEnabled": false,
                 "serverFarmId": "[variables('hostingPlanName')]",
                 "siteConfig": {
                     "appSettings": [
@@ -340,8 +344,7 @@
                 }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             ]
         },
         {
@@ -358,6 +361,7 @@
             }
         },
         {
+            "comments": "Azure CosmosDb",
             "apiVersion": "[variables('documentDBApiVersion')]",
             "type": "Microsoft.DocumentDb/databaseAccounts",
             "name": "[parameters('documentDBName')]",
@@ -376,6 +380,7 @@
             }
         },
         {
+            "comments": "Azure IoT Hub",
             "apiVersion": "[variables('iotHubApiVersion')]",
             "type": "Microsoft.Devices/Iothubs",
             "name": "[parameters('iotHubName')]",
@@ -409,6 +414,7 @@
             "properties": {}
         },
         {
+            "comments": "Security rules used for the VM network interface",
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[variables('networkSecurityGroupName')]",
             "apiVersion": "[variables('networkApiVersion')]",
@@ -458,6 +464,7 @@
             }
         },
         {
+            "comments": "Network interface used by the VM",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('nicName')]",
             "apiVersion": "[variables('networkApiVersion')]",
@@ -485,10 +492,14 @@
                             }
                         }
                     }
-                ]
+                ],
+                "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                }
             }
         },
         {
+            "comments": "VM running the microservices",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('vmName')]",
             "apiVersion": "[variables('computeApiVersion')]",
@@ -541,6 +552,7 @@
             }
         },
         {
+            "comments": "Docker extension used to run the microservices",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('vmName'), '/', 'DockerExtension')]",
             "apiVersion": "[variables('computeApiVersion')]",
@@ -559,6 +571,7 @@
             }
         },
         {
+            "comments": "One time script execution to prepare the VM environment",
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('vmName'), '/', 'scriptextensions')]",
             "apiVersion": "[variables('computeApiVersion')]",

--- a/remotemonitoring/armtemplates/standard-static-map.json
+++ b/remotemonitoring/armtemplates/standard-static-map.json
@@ -263,6 +263,7 @@
             }
         },
         {
+            "comments": "AppService plan to host the Application Gateway Web App",
             "type": "Microsoft.Web/serverfarms",
             "sku": {
                 "name": "[variables('sku')]",
@@ -276,11 +277,14 @@
             }
         },
         {
+            "comments": "Application Gateway Web App",
             "type": "Microsoft.Web/sites",
             "name": "[parameters('azureWebsiteName')]",
             "apiVersion": "2015-08-01",
             "location": "[resourceGroup().location]",
             "properties": {
+                "enabled": true,
+                "clientAffinityEnabled": false,
                 "serverFarmId": "[variables('hostingPlanName')]",
                 "siteConfig": {
                     "appSettings": [
@@ -311,11 +315,11 @@
                 }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             ]
         },
         {
+            "comments": "Azure CosmosDb",
             "apiVersion": "[variables('docDBVersion')]",
             "type": "Microsoft.DocumentDb/databaseAccounts",
             "name": "[parameters('documentDBName')]",
@@ -334,6 +338,7 @@
             }
         },
         {
+            "comments": "Azure IoT Hub",
             "apiVersion": "[variables('iotHubVersion')]",
             "type": "Microsoft.Devices/Iothubs",
             "name": "[parameters('iotHubName')]",

--- a/remotemonitoring/armtemplates/standard.json
+++ b/remotemonitoring/armtemplates/standard.json
@@ -272,6 +272,7 @@
             }
         },
         {
+            "comments": "AppService plan to host the Application Gateway Web App",
             "type": "Microsoft.Web/serverfarms",
             "sku": {
                 "name": "[variables('sku')]",
@@ -285,11 +286,14 @@
             }
         },
         {
+            "comments": "Application Gateway Web App",
             "type": "Microsoft.Web/sites",
             "name": "[parameters('azureWebsiteName')]",
             "apiVersion": "2015-08-01",
             "location": "[resourceGroup().location]",
             "properties": {
+                "enabled": true,
+                "clientAffinityEnabled": false,
                 "serverFarmId": "[variables('hostingPlanName')]",
                 "siteConfig": {
                     "appSettings": [
@@ -320,11 +324,11 @@
                 }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             ]
         },
         {
+            "comments": "Azure CosmosDb",
             "apiVersion": "[variables('docDBVersion')]",
             "type": "Microsoft.DocumentDb/databaseAccounts",
             "name": "[parameters('documentDBName')]",
@@ -343,6 +347,7 @@
             }
         },
         {
+            "comments": "Azure IoT Hub",
             "apiVersion": "[variables('iotHubVersion')]",
             "type": "Microsoft.Devices/Iothubs",
             "name": "[parameters('iotHubName')]",


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Fix for https://github.com/Azure/pcs-cli/issues/200

1. Link the existing Network Security Group to the existing Network Controller Interface, so that network security rules can be applied.
2. Remove dependency of web app on public IP, not required for the deployment, the app is stateless and start working as soon as the IP is available, there is no need to wait
3. Disable client affinity, not required for stateless web applications.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/218)
<!-- Reviewable:end -->
