### PR TITLE
Disable the creation of nohup.out file

### DIFF
--- a/remotemonitoring/single-vm/scripts/start.sh
+++ b/remotemonitoring/single-vm/scripts/start.sh
@@ -32,7 +32,7 @@ if [ -n "$list" ]; then
 fi
 rm -f nohup.out
 
-nohup docker-compose up &
+nohup docker-compose up > /dev/null 2>&1&
 
 ISUP=$(curl -ks https://localhost/ | grep -i "html" | wc -l)
 while [[ "$ISUP" == "0" ]]; do

--- a/remotemonitoring/single-vm/setup.sh
+++ b/remotemonitoring/single-vm/setup.sh
@@ -169,4 +169,4 @@ echo "export PCS_CORS_WHITELIST=\"\""                                           
 
 # ========================================================================
 
-nohup /app/start.sh &
+nohup /app/start.sh > /dev/null 2>&1&


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

When the services start in the basic deployment, a nohup.out file is created.  Since the file includes the output, possibly the logs, it will impact the service perf and potentially fill the disk.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/230)
<!-- Reviewable:end -->
