### PR TITLE
Allowing user to specify service principal and secret

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "sourceMaps": true,
         "program": "${workspaceRoot}/src/index.ts",
         //"args": [ "-r", "java", "-s", "standard" ],
-        "args": [ "-t", "test", "-s", "test" ],
+        "args": [ "-t", "test", "-s", "test", "-p", "e813ad6f-74dd-4369-b0c2-d346a74b2feb", "-secret", "3cd93295-5473-4f51-9f63-2864799e756b"],
         "console": "integratedTerminal",
         "outFiles": [
             "${workspaceRoot}/publish/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "sourceMaps": true,
         "program": "${workspaceRoot}/src/index.ts",
         //"args": [ "-r", "java", "-s", "standard" ],
-        "args": [ "-t", "test", "-s", "test", "-p", "e813ad6f-74dd-4369-b0c2-d346a74b2feb", "-secret", "3cd93295-5473-4f51-9f63-2864799e756b"],
+        "args": [ "-t", "test", "-s", "test" ],
         "console": "integratedTerminal",
         "outFiles": [
             "${workspaceRoot}/publish/**/*.js"

--- a/remotemonitoring/armtemplates/standard-static-map.json
+++ b/remotemonitoring/armtemplates/standard-static-map.json
@@ -225,21 +225,6 @@
         "mastersEndpointDNSNamePrefix": "[concat(parameters('solutionName'),'-mgmt')]",
         "orchestratorType": "Kubernetes",
         "sshRSAPublicKey": "[parameters('sshRSAPublicKey')]",
-        "servicePrincipalClientId": "[parameters('servicePrincipalClientId')]",
-        "servicePrincipalClientSecret": "[parameters('servicePrincipalSecret')]",
-        "useServicePrincipalDictionary": {
-            "DCOS": 0,
-            "Swarm": 0,
-            "Kubernetes": 1
-        },
-        "useServicePrincipal": "[variables('useServicePrincipalDictionary')[variables('orchestratorType')]]",
-        "servicePrincipalFields": [
-            null,
-            {
-                "ClientId": "[parameters('servicePrincipalClientId')]",
-                "Secret": "[parameters('servicePrincipalSecret')]"
-            }
-        ],
         "sku": "S1",
         "workerSize": "0",
         "repoURL": "https://github.com/Azure/reverse-proxy-dotnet.git",
@@ -386,7 +371,10 @@
                         ]
                     }
                 },
-                "servicePrincipalProfile": "[variables('servicePrincipalFields')[variables('useServicePrincipal')]]"
+                "servicePrincipalProfile": {
+                    "ClientId": "[parameters('servicePrincipalClientId')]",
+                    "Secret": "[parameters('servicePrincipalSecret')]"
+                }
             }
         },
         {

--- a/remotemonitoring/armtemplates/standard.json
+++ b/remotemonitoring/armtemplates/standard.json
@@ -232,21 +232,6 @@
         "mastersEndpointDNSNamePrefix": "[concat(parameters('solutionName'),'-mgmt')]",
         "orchestratorType": "Kubernetes",
         "sshRSAPublicKey": "[parameters('sshRSAPublicKey')]",
-        "servicePrincipalClientId": "[parameters('servicePrincipalClientId')]",
-        "servicePrincipalClientSecret": "[parameters('servicePrincipalSecret')]",
-        "useServicePrincipalDictionary": {
-            "DCOS": 0,
-            "Swarm": 0,
-            "Kubernetes": 1
-        },
-        "useServicePrincipal": "[variables('useServicePrincipalDictionary')[variables('orchestratorType')]]",
-        "servicePrincipalFields": [
-            null,
-            {
-                "ClientId": "[parameters('servicePrincipalClientId')]",
-                "Secret": "[parameters('servicePrincipalSecret')]"
-            }
-        ],
         "sku": "S1",
         "workerSize": "0",
         "repoURL": "https://github.com/Azure/reverse-proxy-dotnet.git",
@@ -395,7 +380,10 @@
                         ]
                     }
                 },
-                "servicePrincipalProfile": "[variables('servicePrincipalFields')[variables('useServicePrincipal')]]"
+                "servicePrincipalProfile": {
+                    "ClientId": "[parameters('servicePrincipalClientId')]",
+                    "Secret": "[parameters('servicePrincipalSecret')]"
+                }
             }
         },
         {

--- a/src/deploymentmanager.ts
+++ b/src/deploymentmanager.ts
@@ -337,7 +337,7 @@ export class DeploymentManager implements IDeploymentManager {
             this._parameters.servicePrincipalSecret.value = answers.servicePrincipalSecret;
         }
         if (this._parameters.servicePrincipalClientId) {
-            this._parameters.servicePrincipalClientId.value = answers.appId;
+            this._parameters.servicePrincipalClientId.value = answers.servicePrincipalId;
         }
         if (this._parameters.sshRSAPublicKey) {
             this._parameters.sshRSAPublicKey.value = fs.readFileSync(answers.sshFilePath, 'UTF-8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ const program = new Command(packageJson.name)
             'Azure environments: AzureCloud or AzureChinaCloud',
             /^(AzureCloud|AzureChinaCloud)$/i, 'AzureCloud')
     .option('-r, --runtime <runtime>', 'Microservices runtime: dotnet or java', /^(dotnet|java)$/i, 'dotnet')
-    .option('-p, --servicePrincipalId <servicePrincipalId>', 'Service Principal Id')
-    .option('--secret <secret>', 'Service Principal Secret')
+    .option('--servicePrincipalId <servicePrincipalId>', 'Service Principal Id')
+    .option('--servicePrincipalSecret <servicePrincipalSecret>', 'Service Principal Secret')
     .on('--help', () => {
         console.log(
             `    Default value for ${chalk.green('-t, --type')} is ${chalk.green('remotemonitoring')}.`
@@ -114,8 +114,8 @@ const program = new Command(packageJson.name)
     .parse(process.argv);
 
 if (!program.args[0] || program.args[0] === '-t') {
-    if (program.servicePrincipalId && !program.secret) {
-        console.log('If service principal is provided then secret is required');
+    if (program.servicePrincipalId && !program.servicePrincipalSecret) {
+        console.log('If service principal is provided then servicePrincipalSecret is required');
     } else {
         main();
     }
@@ -335,7 +335,7 @@ function createServicePrincipal(azureWebsiteName: string,
     const identifierUris = [ homepage ];
     const replyUrls = [ homepage ];
     const newServicePrincipalSecret: string = uuid.v4();
-    const existingServicePrincipalSecret: string = program.secret;
+    const existingServicePrincipalSecret: string = program.servicePrincipalSecret;
     // Allowing Graph API to sign in and read user profile for newly created application
     const requiredResourceAccess = [{
         resourceAccess: [
@@ -376,7 +376,7 @@ function createServicePrincipal(azureWebsiteName: string,
         return graphClient.servicePrincipals.create(servicePrincipalCreateParameters);
     })
     .then((sp: any) => {
-        if (program.sku.toLowerCase() === solutionSkus[solutionSkus.basic] || (program.servicePrincipalId && program.secret)) {
+        if (program.sku.toLowerCase() === solutionSkus[solutionSkus.basic] || (program.servicePrincipalId && program.servicePrincipalSecret)) {
             return sp.appId;
         }
 


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
* Added a feature that allows user to specify service principal and secret through command line arguments
* For standard deployment if the user doesn't have owner access to subscription then they can't deploy, this change will allow admin/owner to provide a pre created service principal with contributor access and then user can deploy even if they have contributor role

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
