### PR TITLE
Fix failures in pcs login due to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,8 @@
   },
   "dependencies": {
     "@kubernetes/typescript-node": "0.1.1",
-    "adal-node": "^0.1.26",
     "azure": "2.2.1-preview",
-    "azure-arm-authorization": "^4.1.0",
-    "azure-arm-compute": "^4.0.0",
     "azure-arm-resource": "3.0.0-preview",
-    "azure-arm-website": "^2.0.0-preview",
     "azure-graph": "2.2.0",
     "btoa": "1.1.2",
     "commander": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,12 @@
   },
   "dependencies": {
     "@kubernetes/typescript-node": "0.1.1",
+    "adal-node": "0.1.26",
     "azure": "2.2.1-preview",
+    "azure-arm-authorization": "4.1.0",
+    "azure-arm-compute": "4.0.0",
     "azure-arm-resource": "3.0.0-preview",
+    "azure-arm-website": "2.0.0-preview",
     "azure-graph": "2.2.0",
     "btoa": "1.1.2",
     "commander": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,12 @@
   },
   "dependencies": {
     "@kubernetes/typescript-node": "0.1.1",
+    "adal-node": "^0.1.26",
     "azure": "2.2.1-preview",
+    "azure-arm-authorization": "^4.1.0",
+    "azure-arm-compute": "^4.0.0",
     "azure-arm-resource": "3.0.0-preview",
+    "azure-arm-website": "^2.0.0-preview",
     "azure-graph": "2.2.0",
     "btoa": "1.1.2",
     "commander": "2.9.0",


### PR DESCRIPTION
Missing pre-req dependencies in https://github.com/Azure/pcs-cli/issues/240

# Type of change? <!-- [x] all the boxes that apply -->

- [X ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Bug fix for https://github.com/Azure/pcs-cli/issues/240
Adding missing npm package dependencies that were causing pcs login to fail.

"adal-node": "0.1.26",
"azure-arm-authorization": "4.1.0", 
"azure-arm-compute": "4.0.0", 
 "azure-arm-website": "2.0.0-preview"

**Checklist:**

- [X] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
