### PR TITLE
Change to use 10080/10443 port in API gateway and add read permission on certs volume

### DIFF
--- a/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
@@ -4,8 +4,8 @@ services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:8443"
     depends_on:
       - webui
       - auth

--- a/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
@@ -4,8 +4,8 @@ services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
     ports:
-      - "80:8080"
-      - "443:8443"
+      - "80:10080"
+      - "443:10443"
     depends_on:
       - webui
       - auth

--- a/solutions/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.java.yml
@@ -5,8 +5,8 @@ services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:10080"
+      - "443:10443"
     depends_on:
       - webui
       - auth

--- a/solutions/remotemonitoring/single-vm/setup.sh
+++ b/solutions/remotemonitoring/single-vm/setup.sh
@@ -82,8 +82,8 @@ wget $DOCKERCOMPOSE_SOURCE -O ${DOCKERCOMPOSE}
 
 # HTTPS certificates
 mkdir -p ${CERTS}
-touch ${CERT} && chmod 554 ${CERT}
-touch ${PKEY} && chmod 554 ${PKEY}
+touch ${CERT} && chmod 444 ${CERT}
+touch ${PKEY} && chmod 444 ${PKEY}
 # Always have quotes around the certificate and key value to preserve the formatting
 echo "${PCS_CERTIFICATE}"      > ${CERT}
 echo "${PCS_CERTIFICATE_KEY}"  > ${PKEY}

--- a/solutions/remotemonitoring/single-vm/setup.sh
+++ b/solutions/remotemonitoring/single-vm/setup.sh
@@ -67,6 +67,7 @@ config_for_azure_china $HOST_NAME $5
 # ========================================================================
 
 mkdir -p ${APP_PATH}
+chmod ugo+rX ${APP_PATH}
 cd ${APP_PATH}
 
 # ========================================================================
@@ -81,8 +82,8 @@ wget $DOCKERCOMPOSE_SOURCE -O ${DOCKERCOMPOSE}
 
 # HTTPS certificates
 mkdir -p ${CERTS}
-touch ${CERT} && chmod 550 ${CERT}
-touch ${PKEY} && chmod 550 ${PKEY}
+touch ${CERT} && chmod 554 ${CERT}
+touch ${PKEY} && chmod 554 ${PKEY}
 # Always have quotes around the certificate and key value to preserve the formatting
 echo "${PCS_CERTIFICATE}"      > ${CERT}
 echo "${PCS_CERTIFICATE_KEY}"  > ${PKEY}


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

The API gateway should use non-root user for nginx service. The listening port must be above 1024 for non-root user.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
