### PR TITLE
Define network for docker compose and bind to all containers

### DIFF
--- a/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
+    networks:
+      - default_net
     ports:
       - "80:80"
       - "443:443"
@@ -18,6 +20,8 @@ services:
 
   webui:
     image: azureiotpcs/pcs-remote-monitoring-webui:testing
+    networks:
+      - default_net
     depends_on:
       - auth
       - iothubmanager
@@ -29,6 +33,8 @@ services:
 
   auth:
     image: azureiotpcs/pcs-auth-dotnet:testing
+    networks:
+      - default_net
     environment:
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
@@ -38,6 +44,8 @@ services:
 
   iothubmanager:
     image: azureiotpcs/iothub-manager-dotnet:testing
+    networks:
+      - default_net
     environment:
       - PCS_IOTHUB_CONNSTRING
       # TODO: the dependency on config is temporary
@@ -50,6 +58,8 @@ services:
 
   devicesimulation:
     image: azureiotpcs/device-simulation-dotnet:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
     environment:
@@ -66,6 +76,8 @@ services:
 
   telemetry:
     image: azureiotpcs/telemetry-dotnet:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
     environment:
@@ -79,6 +91,8 @@ services:
 
   config:
     image: azureiotpcs/pcs-config-dotnet:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
       - devicesimulation
@@ -98,6 +112,8 @@ services:
 
   storageadapter:
     image: azureiotpcs/pcs-storage-adapter-dotnet:testing
+    networks:
+      - default_net
     environment:
       - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
       - PCS_AUTH_ISSUER
@@ -108,6 +124,8 @@ services:
 
   telemetryagent:
     image: azureiotpcs/telemetry-agent-dotnet:testing
+    networks:
+      - default_net
     depends_on:
       - telemetry
       - iothubmanager
@@ -129,3 +147,12 @@ services:
       - PCS_AUTH_REQUIRED
       - PCS_CORS_WHITELIST
       - PCS_APPLICATION_SECRET
+
+networks:
+  default_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+       - subnet: 172.18.0.0/16
+         gateway: 172.18.0.1

--- a/solutions/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.java.yml
@@ -4,6 +4,8 @@ version: '2'
 services:
   reverseproxy:
     image: azureiotpcs/remote-monitoring-nginx:testing
+    networks:
+      - default_net
     ports:
       - "80:80"
       - "443:443"
@@ -19,6 +21,8 @@ services:
 
   webui:
     image: azureiotpcs/pcs-remote-monitoring-webui:testing
+    networks:
+      - default_net
     depends_on:
       - auth
       - iothubmanager
@@ -30,6 +34,8 @@ services:
 
   auth:
     image: azureiotpcs/pcs-auth-dotnet:testing
+    networks:
+      - default_net
     environment:
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
@@ -40,6 +46,8 @@ services:
 
   iothubmanager:
     image: azureiotpcs/iothub-manager-java:testing
+    networks:
+      - default_net
     environment:
       - PCS_IOTHUB_CONNSTRING
       # TODO: the dependency on config is temporary
@@ -53,6 +61,8 @@ services:
 
   devicesimulation:
     image: azureiotpcs/device-simulation-dotnet:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
     environment:
@@ -70,6 +80,8 @@ services:
 
   telemetry:
     image: azureiotpcs/telemetry-java:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
     environment:
@@ -84,6 +96,8 @@ services:
 
   config:
     image: azureiotpcs/pcs-config-java:testing
+    networks:
+      - default_net
     depends_on:
       - storageadapter
       - devicesimulation
@@ -104,6 +118,8 @@ services:
 
   storageadapter:
     image: azureiotpcs/pcs-storage-adapter-java:testing
+    networks:
+      - default_net
     environment:
       - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
       - PCS_AUTH_ISSUER
@@ -115,6 +131,8 @@ services:
 
   telemetryagent:
     image: azureiotpcs/telemetry-agent-java:testing
+    networks:
+      - default_net
     depends_on:
       - telemetry
       - iothubmanager
@@ -136,3 +154,12 @@ services:
       - PCS_CORS_WHITELIST
       - PCS_APPLICATION_SECRET
       - APPLICATION_SECRET
+
+networks:
+  default_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+       - subnet: 172.18.0.0/16
+         gateway: 172.18.0.1

--- a/solutions/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.java.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - /app/webui-config.js:/app/build/webui-config.js:ro
 
-  auth
+  auth:
     image: azureiotpcs/pcs-auth-dotnet:${PCS_DOCKER_TAG}
     networks:
       - default_net


### PR DESCRIPTION
The docker0 interface does not allow for filters to be applied and
containers on the network are vulnerable to ARP spoofing and MAC
flooding attacks. Create and setup 'default_net' network and bind all
containers to the defined network to avoid this issue.

PBI[2211813]

# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

...

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
