### PR TITLE
Fix url used for deployments with hub

### DIFF
--- a/solutions/devicesimulation/single-vm/setup.sh
+++ b/solutions/devicesimulation/single-vm/setup.sh
@@ -55,7 +55,7 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-REPOSITORY= "https://raw.githubusercontent.com/Azure/pcs-cli/${PCS_RELEASE_VERSION}/solutions/devicesimulation-nohub/single-vm"
+REPOSITORY= "https://raw.githubusercontent.com/Azure/pcs-cli/${PCS_RELEASE_VERSION}/solutions/devicesimulation/single-vm"
 SCRIPTS_URL="${REPOSITORY}/scripts/"
 
 # ========================================================================


### PR DESCRIPTION
# Description and Motivation

Fix url used in setup script for deployments (with hub)

# Change type

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/319)
<!-- Reviewable:end -->
