### PR TITLE
Fix incorrect docker tag placeholder

### DIFF
--- a/solutions/remotemonitoring/scripts/all-in-one.yaml
+++ b/solutions/remotemonitoring/scripts/all-in-one.yaml
@@ -781,7 +781,7 @@ spec:
     spec:
       containers:
       - name: config-pod
-        image: azureiotpcs/pcs-diagnostics-dotnet:${PCS_DOCKER_TAG}
+        image: azureiotpcs/pcs-diagnostics-dotnet:${dockerTag}
         ports:
         - containerPort: 9006
         env:


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Change PCS_DOCKER_TAG to dockerTag.

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/326)
<!-- Reviewable:end -->
