### PR TITLE
Fix bug of adding application in TSI data policy

### DIFF
--- a/solutions/remotemonitoring/armtemplates/standard-parameters.json
+++ b/solutions/remotemonitoring/armtemplates/standard-parameters.json
@@ -14,7 +14,10 @@
     "sshRSAPublicKey": {
       "value": "{Added through command line interface}"
     },
-    "servicePrincipalClientId": {
+    "aadClientId": {
+      "value": "{Added through command line interface}"
+    },
+    "aadClientServicePrincipalId": {
       "value": "{Added through command line interface}"
     },
     "userPrincipalObjectId": {

--- a/solutions/remotemonitoring/armtemplates/standard-static-map.json
+++ b/solutions/remotemonitoring/armtemplates/standard-static-map.json
@@ -290,7 +290,7 @@
                 "description": "Configure all linux machines with the SSH RSA public key string.  Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
             }
         },
-        "servicePrincipalClientId": {
+        "aadClientId": {
             "metadata": {
                 "description": "Client ID (used by cloudprovider)"
             },
@@ -420,6 +420,13 @@
             "defaultValue": "fakevalue",
             "metadata": {
                 "description": "Object Id of the AAD user that will have access to the environment. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
+            }
+        },
+        "aadClientServicePrincipalId": {
+            "type": "string",
+            "defaultValue": "fakevalue",
+            "metadata": {
+                "description": "Service principal Id of the AAD application that will have access to the environment. Available from the Get-AzureRMADServicePrincipal cmdlets"
             }
         }
     },
@@ -759,7 +766,7 @@
                     "name": "[variables('tsiApplicationAccessPolicy')]",
                     "apiVersion": "[variables('tsiApiVersion')]",
                     "properties": {
-                        "principalObjectId": "[parameters('servicePrincipalClientId')]",
+                        "principalObjectId": "[parameters('aadClientId')]",
                         "roles": [
                             "[variables('tsiReaderRole')]"
                         ]
@@ -1023,7 +1030,7 @@
                     }
                 },
                 "servicePrincipalProfile": {
-                    "ClientId": "[parameters('servicePrincipalClientId')]",
+                    "ClientId": "[parameters('aadClientId')]",
                     "Secret": "[parameters('servicePrincipalSecret')]"
                 }
             }

--- a/solutions/remotemonitoring/armtemplates/standard.json
+++ b/solutions/remotemonitoring/armtemplates/standard.json
@@ -312,13 +312,14 @@
                 "description": "Configure all linux machines with the SSH RSA public key string.  Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
             }
         },
-        "servicePrincipalClientId": {
+        "aadClientId": {
             "metadata": {
                 "description": "Client ID (used by cloudprovider)"
             },
             "type": "securestring",
             "defaultValue": "n/a"
         },
+
         "servicePrincipalSecret": {
             "metadata": {
                 "description": "The Service Principal Client Secret."
@@ -442,6 +443,13 @@
             "defaultValue": "fakevalue",
             "metadata": {
                 "description": "Object Id of the AAD user that will have access to the environment. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
+            }
+        },
+        "aadClientServicePrincipalId": {
+            "type": "string",
+            "defaultValue": "fakevalue",
+            "metadata": {
+                "description": "Service principal Id of the AAD application that will have access to the environment. Available from the Get-AzureRMADServicePrincipal cmdlets"
             }
         }
     },
@@ -784,7 +792,7 @@
                     "name": "[variables('tsiApplicationAccessPolicy')]",
                     "apiVersion": "[variables('tsiApiVersion')]",
                     "properties": {
-                        "principalObjectId": "[parameters('servicePrincipalClientId')]",
+                        "principalObjectId": "[parameters('aadClientId')]",
                         "roles": [
                             "[variables('tsiReaderRole')]"
                         ]
@@ -1048,7 +1056,7 @@
                     }
                 },
                 "servicePrincipalProfile": {
-                    "ClientId": "[parameters('servicePrincipalClientId')]",
+                    "ClientId": "[parameters('aadClientId')]",
                     "Secret": "[parameters('servicePrincipalSecret')]"
                 }
             }

--- a/src/deploymentmanager.ts
+++ b/src/deploymentmanager.ts
@@ -380,12 +380,6 @@ export class DeploymentManager implements IDeploymentManager {
         if (this._parameters.servicePrincipalSecret) {
             this._parameters.servicePrincipalSecret.value = answers.servicePrincipalSecret;
         }
-        if (this._parameters.servicePrincipalClientId) {
-            // According to the document, the service principal client id can use appId. When using servicePrincipalId
-            // of answer ACS deployment always fails and complains application was not found.
-            // more detail here: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
-            this._parameters.servicePrincipalClientId.value = answers.appId;
-        }
         if (this._parameters.sshRSAPublicKey) {
             this._parameters.sshRSAPublicKey.value = fs.readFileSync(answers.sshFilePath, 'UTF-8');
         }

--- a/src/k8smanager.ts
+++ b/src/k8smanager.ts
@@ -190,6 +190,7 @@ export class K8sManager implements IK8sManager {
         configMap.data['security.auth.tenant'] = this._config.AADTenantId;
         configMap.data['security.auth.audience'] = this._config.ApplicationId;
         configMap.data['security.auth.issuer'] = 'https://sts.windows.net/' + this._config.AADTenantId + '/';
+        configMap.data['security.auth.serviceprincipal.secret'] = this._config.ServicePrincipalSecret;
         configMap.data['security.application.secret'] = genPassword();
         configMap.data['azure.maps.key'] = this._config.AzureMapsKey ? this._config.AzureMapsKey : '';
         configMap.data['iothub.connstring'] = this._config.IoTHubConnectionString;


### PR DESCRIPTION
* Use application service principal id for TSI data policy
* Rename servicePrincipalClientId to aadClientId since ACS are using
appId which is not service principal id
* Add missing ServicePrincipalSecret for Kubernetes config map

# Description and Motivation <!-- Info & Context so we can review your pull request -->

...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
