### PR TITLE
Increase retries for SFTP client to download credentials

### DIFF
--- a/src/deploymentmanager.ts
+++ b/src/deploymentmanager.ts
@@ -23,7 +23,7 @@ type DeploymentOperationsListResult = ResourceModels.DeploymentOperationsListRes
 type DeploymentOperation = ResourceModels.DeploymentOperation;
 type DeploymentValidateResult = ResourceModels.DeploymentValidateResult;
 
-const MAX_RETRY = 36;
+const MAX_RETRY = 60;
 const KUBEDIR = os.homedir() + path.sep + '.kube';
 
 export interface IDeploymentManager {


### PR DESCRIPTION
* SFTP client sometimes failed to download credentials within max
retries. This might caused by the delay of K8S cluster spinning up.
Increasing max retries will increase the chance to succeed.

# Description and Motivation <!-- Info & Context so we can review your pull request -->

...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/366)
<!-- Reviewable:end -->
