### PR TITLE
Fix bug of missing environment varialbes 'TELEMETRY_STORAGE_TYPE' in K8S

### DIFF
--- a/solutions/remotemonitoring/scripts/all-in-one.yaml
+++ b/solutions/remotemonitoring/scripts/all-in-one.yaml
@@ -641,6 +641,11 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: security.application.secret
+        - name: PCS_TELEMETRY_STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: deployment-configmap
+              key: telemetry.storage.type
 ---
 apiVersion: v1
 kind: Service

--- a/solutions/remotemonitoring/scripts/individual/asa-manager.yaml
+++ b/solutions/remotemonitoring/scripts/individual/asa-manager.yaml
@@ -91,6 +91,11 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: security.application.secret
+        - name: PCS_TELEMETRY_STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: deployment-configmap
+              key: telemetry.storage.type
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/412)
<!-- Reviewable:end -->
