### PR TITLE
Enable HTML in the O365 Logic App connector for Email Actions

### DIFF
--- a/solutions/remotemonitoring/armtemplates/basic-static-map.json
+++ b/solutions/remotemonitoring/armtemplates/basic-static-map.json
@@ -1374,6 +1374,7 @@
                                     "inputs": {
                                         "body": {
                                             "Body": "@body('Parse_JSON')?['body']",
+                                            "IsHtml": true,
                                             "Subject": "Rule Notification ",
                                             "To": "@items('For_each')"
                                         },

--- a/solutions/remotemonitoring/armtemplates/basic.json
+++ b/solutions/remotemonitoring/armtemplates/basic.json
@@ -1442,6 +1442,7 @@
                                     "inputs": {
                                         "body": {
                                             "Body": "@body('Parse_JSON')?['body']",
+                                            "IsHtml": true,
                                             "Subject": "@body('Parse_JSON')?['subject']",
                                             "To": "@items('For_each')"
                                         },

--- a/solutions/remotemonitoring/armtemplates/local.json
+++ b/solutions/remotemonitoring/armtemplates/local.json
@@ -975,6 +975,7 @@
                                     "inputs": {
                                         "body": {
                                             "Body": "@body('Parse_JSON')?['body']",
+                                            "IsHtml": true,
                                             "Subject": "@body('Parse_JSON')?['subject']",
                                             "To": "@items('For_each')"
                                         },

--- a/solutions/remotemonitoring/armtemplates/standard-static-map.json
+++ b/solutions/remotemonitoring/armtemplates/standard-static-map.json
@@ -1191,6 +1191,7 @@
                                     "inputs": {
                                         "body": {
                                             "Body": "@body('Parse_JSON')?['body']",
+                                            "IsHtml": true,
                                             "Subject": "@body('Parse_JSON')?['subject']",
                                             "To": "@items('For_each')"
                                         },

--- a/solutions/remotemonitoring/armtemplates/standard.json
+++ b/solutions/remotemonitoring/armtemplates/standard.json
@@ -1228,6 +1228,7 @@
                                     "inputs": {
                                         "body": {
                                             "Body": "@body('Parse_JSON')?['body']",
+                                            "IsHtml": true,
                                             "Subject": "@body('Parse_JSON')?['subject']",
                                             "To": "@items('For_each')"
                                         },


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
In order for emails to be sent with formatting, we need to enable HTML on the Logic App Connector.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/421)
<!-- Reviewable:end -->
