### PR TITLE
Remove call to 'cat' which can expose secrets on failure

### DIFF
--- a/solutions/devicesimulation-nohub/single-vm/setup-wrapper.sh
+++ b/solutions/devicesimulation-nohub/single-vm/setup-wrapper.sh
@@ -57,6 +57,5 @@ RESULT=$?
 echo "Exit code: $RESULT"
 if [ $RESULT -ne 0 ]; then
     echo "Setup failed, please see log file '${SETUP_LOG}' for more information"
-    cat ${SETUP_LOG}
     exit 1
 fi

--- a/solutions/devicesimulation/single-vm/setup-wrapper.sh
+++ b/solutions/devicesimulation/single-vm/setup-wrapper.sh
@@ -57,6 +57,5 @@ RESULT=$?
 echo "Exit code: $RESULT"
 if [ $RESULT -ne 0 ]; then
     echo "Setup failed, please see log file '${SETUP_LOG}' for more information"
-    cat ${SETUP_LOG}
     exit 1
 fi

--- a/solutions/remotemonitoring/single-vm/setup-wrapper.sh
+++ b/solutions/remotemonitoring/single-vm/setup-wrapper.sh
@@ -30,6 +30,5 @@ RESULT=$?
 echo "Exit code: $RESULT"
 if [ $RESULT -ne 0 ]; then
     echo "Setup failed, please see log file '${SETUP_LOG}' for more information"
-    cat ${SETUP_LOG}
     exit 1
 fi


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Including this call to 'cat' in these scripts goes against the purpose of the setup-wrapper.sh script, which moves error logs potentially containing secrets to the output file in order to prevent those secrets being exposed and captured by the backend of the deployment process.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/434)
<!-- Reviewable:end -->
