### PR TITLE
fix failing local deployment on run time due to environment variables

### DIFF
--- a/src/deploymentmanager.ts
+++ b/src/deploymentmanager.ts
@@ -542,7 +542,7 @@ export class DeploymentManager implements IDeploymentManager {
         data.push(`PCS_SOLUTION_WEBSITE_URL="${outputs.azureWebsite.value}"`);
         data.push(`PCS_DEPLOYMENT_ID=${answers.deploymentId}`);
         data.push(`PCS_IOTHUB_NAME=${outputs.iotHubName.value}`);
-        data.push(`PCS_DIAGNOSTICS_ENDPOINT_URL=${answers.diagnosticsEndpointUrl || ''}`);
+        data.push(`PCS_DIAGNOSTICS_ENDPOINT_URL=${answers.diagnosticsEndpointUrl || 'DEFAULT_DIAGNOSTICS_ENDPOINT_URL'}`);
         data.push(`PCS_APPLICATION_SECRET="${genPassword()}"`);
         data.push(`PCS_OFFICE365_CONNECTION_URL="${outputs.office365ConnectionUrl.value}"`);
         data.push(`PCS_LOGICAPP_ENDPOINT_URL="${outputs.logicAppEndpointUrl.value}"`);
@@ -557,31 +557,37 @@ export class DeploymentManager implements IDeploymentManager {
         data.push(`PCS_AAD_SECRET=${answers.servicePrincipalSecret}`);
         data.push(`PCS_AZURE_STORAGE_ACCOUNT=${outputs.storageConnectionString.value}`);
 
-        const cmd = this.generateEnviornmentCommand(data);
-        this.saveAndExecuteCommand(cmd, answers.solutionName);
-    }
-
-    private generateEnviornmentCommand(data: string[]): string {
-        let cmd = '';
         const osCmdMap = {
             Darwin: 'launchctl setenv ',
             Linux: 'export ',
             Windows_NT: 'SETX ',
         };
-
-        cmd = data.map((envvar) => osCmdMap[os.type()] + envvar.replace('=', ' ')).join('\n');
-        return cmd;
+        this.setEnvironmentVariables(data, osCmdMap);
+        this.saveEnvironmentVariablesToFile(data, osCmdMap, answers.solutionName);
     }
 
-    private saveAndExecuteCommand(cmd: string, solutionName: string) {
+    private saveEnvironmentVariablesToFile(data: string[], osCmdMap: object, solutionName: string) {
+        const fileContent = data.map((envvar) => osCmdMap[os.type()] + envvar.replace('=', ' ')).join('\n');
+
         const pcsTmpDir: string = `${os.homedir()}${path.sep}.pcs${path.sep}`;
         let envFilePath: string = `${pcsTmpDir}${solutionName}.env`;
         if (fs.existsSync(envFilePath)) {
             envFilePath = `${pcsTmpDir}${solutionName}-${Date.now()}.env`;
         }
-        fs.writeFileSync(envFilePath, cmd);
-        cp.execSync(cmd);
+        fs.writeFileSync(envFilePath, fileContent);
         console.log(`Environment variables are saved into file: '${envFilePath}' and sourced for local development.`);
+    }
+
+    private setEnvironmentVariables(data: string[], osCmdMap: object) {
+        data.forEach((envvar) => {
+            let cmd;
+            try {
+                cmd = osCmdMap[os.type()] + envvar.replace('=', ' ');
+                cp.execSync(cmd);
+            } catch (ex) {
+                console.log(`Failed to set environment variable. envvar = '${envvar})', cmd = '${cmd}', error = '${ex.stderr}'`);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Local deployment from CLI failed on run-time because of wrong environment variables.
There were two issues.
1. executing multiple setx commands joined by new line failed. 
2. PCS_DIAGNOSTICS_ENDPOINT_URL did not have value so that it was syntax error.

Fix:
1. adding default value for diagnostics endpoint environment variable
2. execute setx command individually and if command fails, catch an error and print error message to console.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/449)
<!-- Reviewable:end -->
