### PR TITLE
Revert RM upgrade to DS-2.0.2

### DIFF
--- a/solutions/devicesimulation-nohub/single-vm/docker-compose.yml
+++ b/solutions/devicesimulation-nohub/single-vm/docker-compose.yml
@@ -77,7 +77,6 @@ services:
       - PCS_RESOURCE_GROUP_LOCATION
       - PCS_VMSS_NAME
       - PCS_SEED_TEMPLATE
-      - PCS_SOLUTION_TYPE
     logging:
       driver: "json-file"
       options:

--- a/solutions/devicesimulation/single-vm/docker-compose.yml
+++ b/solutions/devicesimulation/single-vm/docker-compose.yml
@@ -77,7 +77,6 @@ services:
       - PCS_RESOURCE_GROUP_LOCATION
       - PCS_VMSS_NAME
       - PCS_SEED_TEMPLATE
-      - PCS_SOLUTION_TYPE
     logging:
       driver: "json-file"
       options:

--- a/solutions/remotemonitoring/scripts/all-in-one.yaml
+++ b/solutions/remotemonitoring/scripts/all-in-one.yaml
@@ -198,7 +198,7 @@ spec:
     spec:
       containers:
       - name: device-simulation-pod
-        image: azureiotpcs/device-simulation-dotnet:DS-2.0.2
+        image: azureiotpcs/device-simulation-dotnet:DS-1.0.2
         ports:
         - containerPort: 9003
         env:
@@ -232,66 +232,11 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: security.cors.whitelist
-        - name: PCS_SUBSCRIPTION_ID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.subscription.id
-        - name: PCS_WEBUI_AUTH_AAD_APPID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.audience
-        - name: PCS_WEBUI_AUTH_AAD_TENANT
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.tenant
-        - name: PCS_AAD_CLIENT_SP_ID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.audience
-        - name: PCS_AAD_SECRET
+        - name: PCS_APPLICATION_SECRET
           valueFrom:
             configMapKeyRef:
               name: deployment-configmap
               key: security.application.secret
-        - name: PCS_RESOURCE_GROUP
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.solution.name
-        - name: PCS_IOHUB_NAME
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.iothub.name
-        - name: PCS_DIAGNOSTICS_WEBSERVICE_URL
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.endpoint.url
-        - name: PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: docdb.connstring
-        - name: PCS_AZURE_STORAGE_ACCOUNT
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: azureblob.connstring
-        - name: PCS_SEED_TEMPLATE
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: devicesimulation.template
-        - name: PCS_SOLUTION_TYPE
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.solution.type
 ---
 apiVersion: v1
 kind: Service

--- a/solutions/remotemonitoring/scripts/individual/deployment-configmap.yaml
+++ b/solutions/remotemonitoring/scripts/individual/deployment-configmap.yaml
@@ -50,7 +50,6 @@ data:
 
   # Device Simulation
   devicesimulation.webservice.url: "http://device-simulation-svc:9003/v1"
-  devicesimulation.template: "remote-monitoring-simulations-template"
 
   # Telemetry
   telemetry.webservice.url: "http://telemetry-svc:9004/v1"

--- a/solutions/remotemonitoring/scripts/individual/device-simulation.yaml
+++ b/solutions/remotemonitoring/scripts/individual/device-simulation.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: device-simulation-pod
-        image: azureiotpcs/device-simulation-dotnet:DS-2.0.2
+        image: azureiotpcs/device-simulation-dotnet:DS-1.0.2
         ports:
         - containerPort: 9003
         env:
@@ -51,66 +51,11 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: security.cors.whitelist
-        - name: PCS_SUBSCRIPTION_ID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.subscription.id
-        - name: PCS_WEBUI_AUTH_AAD_APPID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.audience
-        - name: PCS_WEBUI_AUTH_AAD_TENANT
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.tenant
-        - name: PCS_AAD_CLIENT_SP_ID
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: security.auth.audience
-        - name: PCS_AAD_SECRET
+        - name: PCS_APPLICATION_SECRET
           valueFrom:
             configMapKeyRef:
               name: deployment-configmap
               key: security.application.secret
-        - name: PCS_RESOURCE_GROUP
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.solution.name
-        - name: PCS_IOHUB_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: deployment-configmap
-                key: diagnostics.iothub.name 
-        - name: PCS_DIAGNOSTICS_WEBSERVICE_URL
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.endpoint.url
-        - name: PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: docdb.connstring
-        - name: PCS_AZURE_STORAGE_ACCOUNT
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: azureblob.connstring
-        - name: PCS_SEED_TEMPLATE
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: devicesimulation.template
-        - name: PCS_SOLUTION_TYPE
-          valueFrom:
-            configMapKeyRef:
-              name: deployment-configmap
-              key: diagnostics.solution.type
 ---
 apiVersion: v1
 kind: Service

--- a/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
@@ -66,39 +66,22 @@ services:
       - PCS_APPLICATION_SECRET
 
   devicesimulation:
-    image: azureiotpcs/device-simulation-dotnet:DS-2.0.2
+    image: azureiotpcs/device-simulation-dotnet:DS-1.0.2
     networks:
       - default_net
-    restart: always
     depends_on:
       - storageadapter
     environment:
-      - PCS_LOG_LEVEL
       - PCS_IOTHUB_CONNSTRING
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
       - PCS_AUTH_REQUIRED
       - PCS_CORS_WHITELIST
-      - PCS_SUBSCRIPTION_ID
-      - PCS_WEBUI_AUTH_AAD_APPID=${PCS_AAD_APPID}
-      - PCS_WEBUI_AUTH_AAD_TENANT=${PCS_AAD_TENANT}
-      - PCS_AAD_CLIENT_SP_ID=${PCS_AAD_APPID}
-      - PCS_AAD_SECRET=${PCS_AAD_APPSECRET}
-      - PCS_RESOURCE_GROUP=${PCS_SOLUTION_NAME}
-      - PCS_IOHUB_NAME=${PCS_IOTHUB_NAME}
-      - PCS_DIAGNOSTICS_WEBSERVICE_URL=http://diagnostics:9006/v1
-      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
-      - PCS_AZURE_STORAGE_ACCOUNT=${PCS_AZUREBLOB_CONNSTRING}
-      - PCS_SEED_TEMPLATE=remote-monitoring-simulations-template
-      - PCS_SOLUTION_TYPE
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10240k"
-        max-file: "10"
-    volumes:
-      - /tmp/share:/tmp/share
+      - PCS_APPLICATION_SECRET
+    # How one could mount custom device models
+    #volumes:
+    #  - ./my-device-models:/app/data:ro
 
   telemetry:
     image: azureiotpcs/telemetry-dotnet:${PCS_DOCKER_TAG}

--- a/solutions/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.java.yml
@@ -69,39 +69,23 @@ services:
       - APPLICATION_SECRET
 
   devicesimulation:
-    image: azureiotpcs/device-simulation-dotnet:DS-2.0.2
+    image: azureiotpcs/device-simulation-dotnet:DS-1.0.2
     networks:
       - default_net
-    restart: always
     depends_on:
       - storageadapter
     environment:
-      - PCS_LOG_LEVEL
       - PCS_IOTHUB_CONNSTRING
       - PCS_STORAGEADAPTER_WEBSERVICE_URL=http://storageadapter:9022/v1
       - PCS_AUTH_ISSUER
       - PCS_AUTH_AUDIENCE
       - PCS_AUTH_REQUIRED
       - PCS_CORS_WHITELIST
-      - PCS_SUBSCRIPTION_ID
-      - PCS_WEBUI_AUTH_AAD_APPID=${PCS_AAD_APPID}
-      - PCS_WEBUI_AUTH_AAD_TENANT=${PCS_AAD_TENANT}
-      - PCS_AAD_CLIENT_SP_ID=${PCS_AAD_APPID}
-      - PCS_AAD_SECRET=${PCS_AAD_APPSECRET}
-      - PCS_RESOURCE_GROUP=${PCS_SOLUTION_NAME}
-      - PCS_IOHUB_NAME=${PCS_IOTHUB_NAME}
-      - PCS_DIAGNOSTICS_WEBSERVICE_URL=http://diagnostics:9006/v1
-      - PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING
-      - PCS_AZURE_STORAGE_ACCOUNT=${PCS_AZUREBLOB_CONNSTRING}
-      - PCS_SEED_TEMPLATE=remote-monitoring-simulations-template
-      - PCS_SOLUTION_TYPE
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10240k"
-        max-file: "10"
-    volumes:
-      - /tmp/share:/tmp/share
+      - PCS_APPLICATION_SECRET
+      - APPLICATION_SECRET
+    # How one could mount custom device models
+    #volumes:
+    #  - ./my-device-models:/app/data:ro
 
   telemetry:
     image: azureiotpcs/telemetry-java:${PCS_DOCKER_TAG}

--- a/src/deploymentmanager.ts
+++ b/src/deploymentmanager.ts
@@ -548,14 +548,6 @@ export class DeploymentManager implements IDeploymentManager {
         data.push(`PCS_LOGICAPP_ENDPOINT_URL="${outputs.logicAppEndpointUrl.value}"`);
         data.push(`PCS_ARM_ENDPOINT_URL="${this._environment.resourceManagerEndpointUrl}"`);
         data.push(`PCS_AAD_ENDPOINT_URL="${this._environment.activeDirectoryEndpointUrl}"`);
-        // Simulation env-vars
-        data.push(`PCS_RESOURCE_GROUP=${answers.solutionName}`);
-        data.push(`PCS_IOHUB_NAME=${outputs.iotHubName.value}`);
-        data.push(`PCS_WEBUI_AUTH_AAD_APPID=${answers.appId}`);
-        data.push(`PCS_WEBUI_AUTH_AAD_TENANT=${answers.aadTenantId}`);
-        data.push(`PCS_AAD_CLIENT_SP_ID=${answers.appId}`);
-        data.push(`PCS_AAD_SECRET=${answers.servicePrincipalSecret}`);
-        data.push(`PCS_AZURE_STORAGE_ACCOUNT=${outputs.storageConnectionString.value}`);
 
         const cmd = this.generateEnviornmentCommand(data);
         this.saveAndExecuteCommand(cmd, answers.solutionName);


### PR DESCRIPTION
Revert "Upgrade to DS-2.0.2 (#446)" due to being unable to add simulated devices. It will be upgraded again once this support is reintroduced in
the latest version.

This reverts commit b45e0d4898ee2c14c8b879b89163ee63bcbca581.

# Description and Motivation <!-- Info & Context so we can review your pull request -->

...

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/450)
<!-- Reviewable:end -->
