### PR TITLE
Making applicationInsightsInstrumentationKey a securestring

### DIFF
--- a/solutions/remotemonitoring/armtemplates/basic-static-map.json
+++ b/solutions/remotemonitoring/armtemplates/basic-static-map.json
@@ -536,7 +536,7 @@
             }
         },
         "applicationInsightsInstrumentationKey": {
-            "type": "string",
+            "type": "securestring",
              "defaultValue": "Undefined",
              "metadata": {
                 "description": "The Application Insights instrumentation key for this deployment type"


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Making applicationInsightsInstrumentationKey a securestring so that user's won't see it in ARM deployment logs

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/470)
<!-- Reviewable:end -->
