### PR TITLE
PCS_CONFIG_URL

### DIFF
--- a/solutions/remotemonitoring/scripts/all-in-one.yaml
+++ b/solutions/remotemonitoring/scripts/all-in-one.yaml
@@ -958,7 +958,7 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: diagnostics.appinsights.instrumentationkey
-        - name: PCS_CONFIG_WEBSERVICE_URL
+        - name: PCS_CONFIG_URL
           valueFrom:
             configMapKeyRef:
               name: deployment-configmap

--- a/solutions/remotemonitoring/scripts/individual/diagnostics.yaml
+++ b/solutions/remotemonitoring/scripts/individual/diagnostics.yaml
@@ -78,7 +78,7 @@ spec:
             configMapKeyRef:
               name: deployment-configmap
               key: diagnostics.iothub.name
-        - name: PCS_CONFIG_WEBSERVICE_URL
+        - name: PCS_CONFIG_URL
           valueFrom:
             configMapKeyRef:
               name: deployment-configmap

--- a/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.dotnet.yml
@@ -209,7 +209,7 @@ services:
       - PCS_SOLUTION_NAME
       - PCS_DEPLOYMENT_ID
       - PCS_IOTHUB_NAME
-      - PCS_CONFIG_WEBSERVICE_URL=http://config:9005/v1
+      - PCS_CONFIG_URL=http://config:9005/v1
       - PCS_APPINSIGHTS_INSTRUMENTATIONKEY
 
 networks:

--- a/solutions/remotemonitoring/single-vm/docker-compose.java.yml
+++ b/solutions/remotemonitoring/single-vm/docker-compose.java.yml
@@ -215,7 +215,7 @@ services:
       - PCS_SOLUTION_NAME
       - PCS_DEPLOYMENT_ID
       - PCS_IOTHUB_NAME
-      - PCS_CONFIG_WEBSERVICE_URL=http://config:9005/v1
+      - PCS_CONFIG_URL=http://config:9005/v1
       - PCS_APPINSIGHTS_INSTRUMENTATIONKEY
 
 networks:


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Diagnostics micro-service deployed for RM solutions have been crashing because the service is expecting PCS_CONFIG_URL but the deployment is setting PCS_CONFIG_SERVICE_URL
...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/473)
<!-- Reviewable:end -->
