### PR TITLE
BlackListing walinuxagent and updating package-lock.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iot-solutions",
-  "version": "2.1.3",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solutions/remotemonitoring/single-vm/setup.sh
+++ b/solutions/remotemonitoring/single-vm/setup.sh
@@ -95,6 +95,7 @@ install_docker_ce() {
     fi
 
     apt-get update -o Acquire::CompressionTypes::Order::=gz \
+        && apt-mark hold walinuxagent \
         && apt-get upgrade -y \
         && apt-get update \
         && apt-get remove docker docker-engine docker.io \


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

Our setup.sh script for the VMs included the following line:
&& apt-get upgrade -y \

This was (accidentally) causing the script to try to upgrade the agent:
“since your script is running from Microsoft.Azure.Extensions.CustomScript, which is running from walinuxagent, your script triggers a signal to the existing walinuxagent to terminate so it can get upgraded. however, our agent is designed in a way that it waits until all its extensions have finished executing before terminating, so this is a cyclical dependency. what happened in the end is that your script hit a 90 minute timeout configured by Microsoft.Azure.Extensions.CustomScript and died.”

Ubuntu updated the package today.

Which explains why this exact script was working before and why it was taking 90 minutes.

So, the fix will be to blacklist walinuxagent before upgrade script.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/481)
<!-- Reviewable:end -->
