### PR TITLE
Blacklist walinuxagent in VM Extensions CustomScript

### DIFF
--- a/solutions/remotemonitoring/single-vm/setup.sh
+++ b/solutions/remotemonitoring/single-vm/setup.sh
@@ -95,8 +95,10 @@ install_docker_ce() {
     fi
 
     apt-get update -o Acquire::CompressionTypes::Order::=gz \
+        && apt-mark hold walinuxagent \
         && apt-get upgrade -y \
         && apt-get update \
+        && apt-mark unhold walinuxagent \
         && apt-get remove docker docker-engine docker.io \
         && apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --no-install-recommends install apt-transport-https ca-certificates curl gnupg2 software-properties-common \
         && curl -fsSL $DOCKER_DOWNLOAD_URL$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add - \


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Fix for: https://github.com/Azure/pcs-cli/issues/482  

The [CustomScript](https://github.com/Azure/pcs-cli/blob/master/solutions/remotemonitoring/single-vm/setup.sh) for the VMExtension currently calls:

```
apt-get update -o Acquire::CompressionTypes::Order::=gz \
        && apt-get upgrade -y \
        && apt-get update \
```

This unknowlingly triggers an upgrade for WALinuxAgent and waits for the completion of this operation. Since WALinuxAgent is waiting for the extensions to finish running before terminating, this becomes a circular dependency. The dependency causes the CustomScript to time out after 90 minutes and the deployment fails.

This issue came to light only since Ubuntu 1604 updated the walinuxagent package in their repo:
http://changelogs.ubuntu.com/changelogs/pool/main/w/walinuxagent/walinuxagent_2.2.32-0ubuntu1~16.04.2/changelog

To prevent the script from trying to upgrade WALinuxAgent, this PR blacklists the WALinuxAgent before the call by running "apt-mark hold walinuxagent" and "apt-mark unhold walinuxagent" after.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Notes
One open question is around whether or not is information is available in the documentation. The example on docs.microsoft.com does include the upgrade command:
https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux#property-script 

This issue on GitHub also references a similar problem:
https://github.com/Azure/WALinuxAgent/issues/178#issuecomment-281552852 

> Right now there is no supportable way to update the Azure agent package via customscript.  The agent will be restarted as part of the upgrade process, and since > extensions are child processes to the agent process this restart will cause the extension to fail.
> One option is to update the agent using a different mechanism such as via SSH after provisioning."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/487)
<!-- Reviewable:end -->
