### PR TITLE
VM timeout caused by console-setup

### DIFF
--- a/solutions/remotemonitoring/single-vm/setup.sh
+++ b/solutions/remotemonitoring/single-vm/setup.sh
@@ -58,8 +58,12 @@ install_docker_ce() {
         DOCKER_DOWNLOAD_URL="https://download.docker.com/linux/"
     fi
 
+    # The package console-setup tries to prompt the user for an encoding on install thus causing timeouts 
+    # on our installation. For this reason we hold this package.
+
     apt-get update -o Acquire::CompressionTypes::Order::=gz \
         && apt-mark hold walinuxagent \
+        && apt-mark hold console-setup \
         && apt-get upgrade -y \
         && apt-get update \
         && apt-mark unhold walinuxagent \


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
The package console-setup tries to prompt user for an encoding. The package seems to be unnecessary so we can simply mark it as held to not install it.

# Change type <!-- [x] in all the boxes that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**
- [x] All tests passed
- [x] The code follows the code style and conventions of this project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/507)
<!-- Reviewable:end -->
