### PR TITLE
Remove hardcoded allowed values for TSI and Provisioning in ARM templates

### DIFF
--- a/solutions/remotemonitoring/armtemplates/basic-static-map.json
+++ b/solutions/remotemonitoring/armtemplates/basic-static-map.json
@@ -405,16 +405,6 @@
         "tsiLocation" : {
             "type": "string",
             "defaultValue": "eastus2",
-            "allowedValues": [
-                "eastus",
-                "eastus2",
-                "westus",
-                "westus2",
-                "centralus",
-                "westcentralus",
-                "northeurope",
-                "westeurope"
-            ],
             "metadata": {
                 "description": "The location which supports Time Series Insights resource"
             }

--- a/solutions/remotemonitoring/armtemplates/basic.json
+++ b/solutions/remotemonitoring/armtemplates/basic.json
@@ -204,14 +204,6 @@
         "provisioningServiceLocation": {
             "type": "string",
             "defaultValue": "westus",
-            "allowedValues": [
-                "eastus",
-                "westus",
-                "northeurope",
-                "westeurope",
-                "eastasia",
-                "southeastasia"
-            ],
             "metadata": {
                 "description": "The location which supports Device Provisioning Service resource"
             }
@@ -439,16 +431,6 @@
         "tsiLocation" : {
             "type": "string",
             "defaultValue": "eastus2",
-            "allowedValues": [
-                "eastus",
-                "eastus2",
-                "westus",
-                "westus2",
-                "centralus",
-                "westcentralus",
-                "northeurope",
-                "westeurope"
-            ],
             "metadata": {
                 "description": "The location which supports Time Series Insights resource"
             }


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
Remote Moniotoring deployments for the australiaeast and the australiaaoutheast regions were hitting an error on the TSI allowed values part of the ARM template.

TSI now supports australiaeast and australiasoutheast which was showing up as a new option for azureiotsolutions.com due to a dynamic region check. This change removes the hardcoded allowed values in the ARM template for basic deployments. By removing the hardcoded allowed regions, we can rely on the dynamic API call to return a list of allowed regions instead. `provisioningServiceLocation` could hit the same issue so the allowed values in the template have also been removed.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-cli/512)
<!-- Reviewable:end -->
